### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/src/content/blog/nixos-raspberry-pi.mdx
+++ b/src/content/blog/nixos-raspberry-pi.mdx
@@ -187,7 +187,7 @@ The very important part of this is the following:
 }
 ```
 
-For the `fileSystems` part, do refer to the [Partition](#partition) part below. Refer to [Impermanence on NixOS Wiki](https://nixos.wiki/wiki/Impermanence) to setup data persistence on a system with a tmpfs as the root directory.
+For the `fileSystems` part, do refer to the [Partition](#partition) part below. Refer to [Impermanence on NixOS Wiki](https://wiki.nixos.org/wiki/Impermanence) to setup data persistence on a system with a tmpfs as the root directory.
 
 ## Install NixOS on Raspberry Pi
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️